### PR TITLE
make descriptions less surprising

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Single line breaks in descriptions are rendered less surprisingly ([#227](https://github.com/cucumber/react-components/pull/227))
 
 ## [20.1.0] - 2022-05-27
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "react-markdown": "6.0.3",
         "rehype-raw": "5.1.0",
         "rehype-sanitize": "4.0.0",
+        "remark-breaks": "2.0.2",
         "remark-gfm": "1.0.0"
       },
       "devDependencies": {
@@ -25071,6 +25072,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/remark-breaks": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-2.0.2.tgz",
+      "integrity": "sha512-LsQnPPQ7Fzp9RTjj4IwdEmjPOr9bxe9zYKWhs9ZQOg9hMg8rOfeeqQ410cvVdIK87Famqza1CKRxNkepp2EvUA==",
+      "dependencies": {
+        "unist-util-visit": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-footnotes": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/remark-footnotes/-/remark-footnotes-2.0.0.tgz",
@@ -47967,6 +47980,14 @@
       "dev": true,
       "requires": {
         "es6-error": "^4.0.1"
+      }
+    },
+    "remark-breaks": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-2.0.2.tgz",
+      "integrity": "sha512-LsQnPPQ7Fzp9RTjj4IwdEmjPOr9bxe9zYKWhs9ZQOg9hMg8rOfeeqQ410cvVdIK87Famqza1CKRxNkepp2EvUA==",
+      "requires": {
+        "unist-util-visit": "^2.0.0"
       }
     },
     "remark-footnotes": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "react-markdown": "6.0.3",
     "rehype-raw": "5.1.0",
     "rehype-sanitize": "4.0.0",
+    "remark-breaks": "2.0.2",
     "remark-gfm": "1.0.0"
   },
   "peerDependencies": {

--- a/src/components/app/HighLight.tsx
+++ b/src/components/app/HighLight.tsx
@@ -5,6 +5,7 @@ import ReactMarkdown from 'react-markdown'
 
 import SearchQueryContext from '../../SearchQueryContext'
 import rehypePlugins from './rehypePlugins'
+import remarkPlugins from './remarkPlugins'
 
 interface IProps {
   text: string
@@ -44,7 +45,9 @@ export const HighLight: React.FunctionComponent<IProps> = ({
 
     return (
       <div className={appliedClassName}>
-        <ReactMarkdown rehypePlugins={rehypePlugins}>{highlightedText}</ReactMarkdown>
+        <ReactMarkdown remarkPlugins={remarkPlugins} rehypePlugins={rehypePlugins}>
+          {highlightedText}
+        </ReactMarkdown>
       </div>
     )
   }

--- a/src/components/app/remarkPlugins.ts
+++ b/src/components/app/remarkPlugins.ts
@@ -1,0 +1,5 @@
+import { PluggableList } from 'react-markdown'
+import remarkBreaks from 'remark-breaks'
+
+const plugins: PluggableList = [remarkBreaks]
+export default plugins

--- a/src/components/gherkin/Description.spec.tsx
+++ b/src/components/gherkin/Description.spec.tsx
@@ -36,7 +36,7 @@ I want to do stuff
 So that I can be happy`
     const { container } = render(<Description description={description} />)
     expect(container).toContainHTML(
-      '<p>As a user<br>I want to do stuff<br>So that I can be happy</p>'
+      '<p>As a user<br/>\nI want to do stuff<br/>\nSo that I can be happy</p>'
     )
   })
 })

--- a/src/components/gherkin/Description.spec.tsx
+++ b/src/components/gherkin/Description.spec.tsx
@@ -29,4 +29,14 @@ describe('Description', () => {
     const { getByRole } = render(<Description description={'## This is a heading'} />)
     expect(getByRole('heading', { name: 'This is a heading' })).toBeVisible()
   })
+
+  it('honours single line breaks in descriptions', () => {
+    const description = `As a user
+I want to do stuff
+So that I can be happy`
+    const { container } = render(<Description description={description} />)
+    expect(container).toContainHTML(
+      '<p>As a user<br>I want to do stuff<br>So that I can be happy</p>'
+    )
+  })
 })


### PR DESCRIPTION
### 🤔 What's changed?

Use [remark-breaks](https://github.com/remarkjs/remark-breaks) to mimic the behaviour of GitHub comments etc where single line breaks are honoured without requiring an escape or double space.

### ⚡️ What's your motivation? 

Fixes #225

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
