### PR TITLE
test: use act() to avoid deprecation warnings

### DIFF
--- a/src/components/app/SearchWrapper.spec.tsx
+++ b/src/components/app/SearchWrapper.spec.tsx
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/react'
 import React from 'react'
+import { act } from 'react-dom/test-utils'
 
 import SearchQueryContext, { SearchQueryCtx, SearchQueryProps } from '../../SearchQueryContext'
 import { SearchWrapper } from './SearchWrapper'
@@ -34,8 +35,10 @@ describe('SearchWrapper', () => {
     const sq1 = searchQueryCapture.mock.calls[0][0]
     searchQueryCapture.mockReset()
 
-    // When the query is updated
-    sq1.update({ query: 'foo' })
+    act(() => {
+      // When the query is updated
+      sq1.update({ query: 'foo' })
+    })
 
     // Then...
     expect(searchQueryCapture).toHaveBeenCalledTimes(1)
@@ -50,8 +53,10 @@ describe('SearchWrapper', () => {
 
     expect(sq1.query).toEqual('foo')
 
-    // When the query is updated
-    sq1.update({ query: 'bar' })
+    act(() => {
+      // When the query is updated
+      sq1.update({ query: 'bar' })
+    })
 
     // Then...
     expect(searchQueryCapture).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
### 🤔 What's changed?

This change avoids deprecation warnings output when running the tests. I wrapped actions as callbacks to `act`.

Nice introduction to `act`, here: https://reactjs.org/docs/test-utils.html#act



### ⚡️ What's your motivation? 

We like a no-warnings test output.

The warnings looked like:

<details>

```
  ● Console

    console.error
      Warning: An update to SearchWrapper inside a test was not wrapped in act(...).

      When testing, code that causes React state updates should be wrapped into act(...):

      act(() => {
        /* fire events that update state */
      });
      /* assert on the output */

      This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
          at SearchWrapper (/Users/olle/opensource/react-components/src/components/app/SearchWrapper.tsx:6:3)

      85 |     this.hideStatuses = value.hideStatuses
      86 |     this.update = (values: SearchQueryUpdate) => {
    > 87 |       updateValue({
         |       ^
      88 |         query: values.query ?? this.query,
      89 |         hideStatuses: values.hideStatuses ?? this.hideStatuses,
      90 |       })

      at printWarning (node_modules/react-dom/cjs/react-dom.development.js:67:30)
      at error (node_modules/react-dom/cjs/react-dom.development.js:43:5)
      at warnIfNotCurrentlyActingUpdatesInDEV (node_modules/react-dom/cjs/react-dom.development.js:24064:9)
      at dispatchAction (node_modules/react-dom/cjs/react-dom.development.js:16135:9)
      at SearchQueryCtx.update (src/SearchQueryContext.ts:87:7)
      at Object.<anonymous> (src/components/app/SearchWrapper.spec.tsx:38:9)
```

</details>

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

Not really. I came here to check what it took to get to React 18.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
