### PR TITLE
feat: support TestStepResult.exception

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "22.0.0",
       "license": "MIT",
       "dependencies": {
-        "@cucumber/gherkin-utils": "^8.0.0",
-        "@cucumber/messages": "^21.0.0",
-        "@cucumber/query": "^12.0.0",
-        "@cucumber/tag-expressions": "^5.0.0",
+        "@cucumber/gherkin-utils": "8.0.6",
+        "@cucumber/messages": "24.0.1",
+        "@cucumber/query": "12.0.1",
+        "@cucumber/tag-expressions": "6.1.0",
         "@fortawesome/fontawesome-svg-core": "6.2.1",
         "@fortawesome/free-solid-svg-icons": "6.2.1",
         "@fortawesome/react-fontawesome": "0.2.0",
@@ -34,11 +34,11 @@
         "use-debounce": "^10.0.0"
       },
       "devDependencies": {
-        "@cucumber/compatibility-kit": "^12.0.0",
-        "@cucumber/fake-cucumber": "^16.0.0",
-        "@cucumber/gherkin": "^26.0.0",
-        "@cucumber/gherkin-streams": "^5.0.1",
-        "@cucumber/message-streams": "^4.0.1",
+        "@cucumber/compatibility-kit": "15.0.0",
+        "@cucumber/fake-cucumber": "16.4.0",
+        "@cucumber/gherkin": "28.0.0",
+        "@cucumber/gherkin-streams": "5.0.1",
+        "@cucumber/message-streams": "4.0.1",
         "@ladle/react": "^2.4.5",
         "@testing-library/react": "14.1.2",
         "@testing-library/user-event": "14.5.1",
@@ -1880,33 +1880,33 @@
       "dev": true
     },
     "node_modules/@cucumber/compatibility-kit": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/compatibility-kit/-/compatibility-kit-12.0.0.tgz",
-      "integrity": "sha512-p+wvlFLoYILwsCcKpai/2lnTby/02gvtcIb22fC59srDAQapXhLwcR7irHbX4Hhj+06TbQLSMbd1T2uZrccJzw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/compatibility-kit/-/compatibility-kit-15.0.0.tgz",
+      "integrity": "sha512-5pzgNY0ylsQpcU0CxTBIRlo7+2F1helz/CUMbgE8E7IBxKVQ1czA/WgWtHoeVGm0i0zK5QE7TyDOUL5Nikek0Q==",
       "dev": true
     },
     "node_modules/@cucumber/cucumber-expressions": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-15.2.0.tgz",
-      "integrity": "sha512-qAzz9ogcTuosFZYfueSTWnD6KxiIAAu09HwLwz1XhYL/MhfLjyq1iQN6mOnKln/hr2jX/U98C92VAlquhXDo7Q==",
+      "version": "16.1.2",
+      "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-16.1.2.tgz",
+      "integrity": "sha512-CfHEbxJ5FqBwF6mJyLLz4B353gyHkoi6cCL4J0lfDZ+GorpcWw4n2OUAdxJmP7ZlREANWoTFlp4FhmkLKrCfUA==",
       "dev": true,
       "dependencies": {
         "regexp-match-indices": "1.0.2"
       }
     },
     "node_modules/@cucumber/fake-cucumber": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/fake-cucumber/-/fake-cucumber-16.0.0.tgz",
-      "integrity": "sha512-wTd+/SSTbg1MOKNniameGfMAvlgbCFZ7LdRAPSyr0lGZ7QOIeGcIEh5c0EZov/PyPMbsyk3ddTyTpXQZBOTmyg==",
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/fake-cucumber/-/fake-cucumber-16.4.0.tgz",
+      "integrity": "sha512-wBkirB5ha0hsN2GV5hQHwLJBJMImvemzIWgr/ah+bzZ1vsaHO/Qov903sZ3R5MiV8x6Nn4au7162VKi2AyX+PQ==",
       "dev": true,
       "dependencies": {
         "@cucumber/ci-environment": "^9.0.4",
-        "@cucumber/cucumber-expressions": "^15.0.0",
-        "@cucumber/tag-expressions": "^4.1.0",
-        "@types/stack-utils": "2.0.1",
-        "commander": "9.3.0",
-        "glob": "8.0.3",
-        "stack-utils": "2.0.5"
+        "@cucumber/cucumber-expressions": "^16.0.0",
+        "@cucumber/tag-expressions": "^6.0.0",
+        "@types/stack-utils": "2.0.3",
+        "commander": "11.1.0",
+        "glob": "10.3.10",
+        "stack-utils": "2.0.6"
       },
       "bin": {
         "fake-cucumber": "bin/fake-cucumber"
@@ -1919,12 +1919,6 @@
         "@cucumber/messages": ">=19.0"
       }
     },
-    "node_modules/@cucumber/fake-cucumber/node_modules/@cucumber/tag-expressions": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/tag-expressions/-/tag-expressions-4.1.0.tgz",
-      "integrity": "sha512-chTnjxV3vryL75N90wJIMdMafXmZoO2JgNJLYpsfcALL2/IQrRiny3vM9DgD5RDCSt1LNloMtb7rGey9YWxCsA==",
-      "dev": true
-    },
     "node_modules/@cucumber/fake-cucumber/node_modules/brace-expansion": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
@@ -1934,44 +1928,78 @@
         "balanced-match": "^1.0.0"
       }
     },
-    "node_modules/@cucumber/fake-cucumber/node_modules/glob": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
-      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+    "node_modules/@cucumber/fake-cucumber/node_modules/foreground-child": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
       "dev": true,
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@cucumber/fake-cucumber/node_modules/glob": {
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.3.5",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@cucumber/fake-cucumber/node_modules/minimatch": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.4.tgz",
-      "integrity": "sha512-U0iNYXt9wALljzfnGkhFSy5sAC6/SCR3JrHrlsdJz4kF8MvhTRQNiC59iUi1iqsitV7abrNAJWElVL9pdnoUgw==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@cucumber/fake-cucumber/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@cucumber/gherkin": {
-      "version": "26.0.1",
-      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-26.0.1.tgz",
-      "integrity": "sha512-yQvXyvLrcKtfHT6omI6/Sn4e4Hr/nrkR2wezrzy9+ghDg1FqeDimrID5jQcQRo0bO9QWTgq2nUKrrowCITUZeQ==",
+      "version": "28.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-28.0.0.tgz",
+      "integrity": "sha512-Ee6zJQq0OmIUPdW0mSnsCsrWA2PZAELNDPICD2pLfs0Oz7RAPgj80UsD2UCtqyAhw2qAR62aqlktKUlai5zl/A==",
       "dev": true,
       "dependencies": {
-        "@cucumber/messages": "^21.0.0"
+        "@cucumber/messages": ">=19.1.4 <=24"
       }
     },
     "node_modules/@cucumber/gherkin-streams": {
@@ -2002,17 +2030,56 @@
       }
     },
     "node_modules/@cucumber/gherkin-utils": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/gherkin-utils/-/gherkin-utils-8.0.0.tgz",
-      "integrity": "sha512-8uIZInEe3cO1cASmy3BA0PbVFUI+xWBnZAxmICbVOPsZaMB85MtESZLafzErgfRQPsHf6uYbVagP7MIjNPM5Jw==",
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin-utils/-/gherkin-utils-8.0.6.tgz",
+      "integrity": "sha512-mtTXKJ5+yWTsMGf7gV7Q/57WpQHqzSgA8yMXzBalsSqLGaze+Pw+bPsHr077SBDLHuDn4o53tWrLMIRnQyJEmQ==",
       "dependencies": {
-        "@cucumber/messages": "^19.0.0",
-        "@teppeis/multimaps": "2.0.0",
-        "commander": "9.3.0"
+        "@cucumber/gherkin": "^27.0.0",
+        "@cucumber/messages": "^24.0.0",
+        "@teppeis/multimaps": "3.0.0",
+        "commander": "11.1.0",
+        "source-map-support": "^0.5.21"
       },
       "bin": {
         "gherkin-utils": "bin/gherkin-utils"
       }
+    },
+    "node_modules/@cucumber/gherkin-utils/node_modules/@cucumber/gherkin": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-27.0.0.tgz",
+      "integrity": "sha512-j5rCsjqzRiC3iVTier3sa0kzyNbkcAmF7xr7jKnyO7qDeK3Z8Ye1P3KSVpeQRMY+KCDJ3WbTDdyxH0FwfA/fIw==",
+      "dependencies": {
+        "@cucumber/messages": ">=19.1.4 <=22"
+      }
+    },
+    "node_modules/@cucumber/gherkin-utils/node_modules/@cucumber/gherkin/node_modules/@cucumber/messages": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-22.0.0.tgz",
+      "integrity": "sha512-EuaUtYte9ilkxcKmfqGF9pJsHRUU0jwie5ukuZ/1NPTuHS1LxHPsGEODK17RPRbZHOFhqybNzG2rHAwThxEymg==",
+      "dependencies": {
+        "@types/uuid": "9.0.1",
+        "class-transformer": "0.5.1",
+        "reflect-metadata": "0.1.13",
+        "uuid": "9.0.0"
+      }
+    },
+    "node_modules/@cucumber/gherkin-utils/node_modules/@teppeis/multimaps": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@teppeis/multimaps/-/multimaps-3.0.0.tgz",
+      "integrity": "sha512-ID7fosbc50TbT0MK0EG12O+gAP3W3Aa/Pz4DaTtQtEvlc9Odaqi0de+xuZ7Li2GtK4HzEX7IuRWS/JmZLksR3Q==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@cucumber/gherkin-utils/node_modules/@types/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA=="
+    },
+    "node_modules/@cucumber/gherkin-utils/node_modules/reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
     },
     "node_modules/@cucumber/message-streams": {
       "version": "4.0.1",
@@ -2024,9 +2091,29 @@
       }
     },
     "node_modules/@cucumber/messages": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-21.0.0.tgz",
-      "integrity": "sha512-riglVBP45dGoQ1n38/wXZDxQuJ0KkpvTpIq68Ui5EaV06HDdJpVXVzujr8s67K2NDRRKfnf556aFdrh0Mo0cUQ==",
+      "version": "24.0.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-24.0.1.tgz",
+      "integrity": "sha512-dKfNkvgc6stSQIyeHk7p/221iqEZe1BP+e/Js8XKtSmc0sS8khKMvbSBwYVeonn/67/vYKiAyo6Eo0SzXd5Plw==",
+      "dependencies": {
+        "@types/uuid": "9.0.7",
+        "class-transformer": "0.5.1",
+        "reflect-metadata": "0.2.1",
+        "uuid": "9.0.1"
+      }
+    },
+    "node_modules/@cucumber/query": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/query/-/query-12.0.1.tgz",
+      "integrity": "sha512-Dk6RGtzFRjylzp6N5jJOylIPxGr0pBr6KtHGTf/74RDFpx2FXpZJSPbEuXkLxtTUBiubVDfouH/oXbiZ17kTrQ==",
+      "dependencies": {
+        "@cucumber/messages": "^19.1.4",
+        "@teppeis/multimaps": "2.0.0"
+      }
+    },
+    "node_modules/@cucumber/query/node_modules/@cucumber/messages": {
+      "version": "19.1.4",
+      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-19.1.4.tgz",
+      "integrity": "sha512-Pksl0pnDz2l1+L5Ug85NlG6LWrrklN9qkMxN5Mv+1XZ3T6u580dnE6mVaxjJRdcOq4tR17Pc0RqIDZMyVY1FlA==",
       "dependencies": {
         "@types/uuid": "8.3.4",
         "class-transformer": "0.5.1",
@@ -2034,19 +2121,20 @@
         "uuid": "9.0.0"
       }
     },
-    "node_modules/@cucumber/query": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/query/-/query-12.0.0.tgz",
-      "integrity": "sha512-MU4jdYMeWtATXdp2juX6c4QRFDlo0OJd3vpiv0zzAcVccYpEx+P2/BgFeUv9qhUZXSQB7wOSKCa1ZZkdSb6QXA==",
-      "dependencies": {
-        "@cucumber/messages": "^19.0.0",
-        "@teppeis/multimaps": "2.0.0"
-      }
+    "node_modules/@cucumber/query/node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
+    },
+    "node_modules/@cucumber/query/node_modules/reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
     },
     "node_modules/@cucumber/tag-expressions": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@cucumber/tag-expressions/-/tag-expressions-5.0.1.tgz",
-      "integrity": "sha512-N43uWud8ZXuVjza423T9ZCIJsaZhFekmakt7S9bvogTxqdVGbRobjR663s0+uW0Rz9e+Pa8I6jUuWtoBLQD2Mw=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/tag-expressions/-/tag-expressions-6.1.0.tgz",
+      "integrity": "sha512-+3DwRumrCJG27AtzCIL37A/X+A/gSfxOPLg8pZaruh5SLumsTmpvilwroVWBT2fPzmno/tGXypeK5a7NHU4RzA=="
     },
     "node_modules/@cush/relative": {
       "version": "1.0.0",
@@ -2169,6 +2257,102 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -2447,6 +2631,16 @@
       "integrity": "sha512-JQKG0TFlzAfeBSQlEx9avhpY20BCXfAlFPNXJWwvUhWDfWVhO5HBAzEUU+gHfI4oHDHnydpKGlA2z6kka2T4Tw==",
       "engines": {
         "node": ">= 16.0.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -2851,9 +3045,9 @@
       "dev": true
     },
     "node_modules/@types/stack-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
-      "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
     },
     "node_modules/@types/tough-cookie": {
@@ -2868,9 +3062,9 @@
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
     },
     "node_modules/@types/uuid": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.7.tgz",
+      "integrity": "sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.48.1",
@@ -3905,8 +4099,7 @@
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "node_modules/bundle-name": {
       "version": "3.0.0",
@@ -4256,11 +4449,11 @@
       }
     },
     "node_modules/commander": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.3.0.tgz",
-      "integrity": "sha512-hv95iU5uXPbK83mjrJKuZyFM/LBAoCV/XhVGkS5Je6tl7sxr6A0ITMw5WoRV46/UaJ46Nllm3Xt7IaJhXTIkzw==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
       "engines": {
-        "node": "^12.20.0 || >=14"
+        "node": ">=16"
       }
     },
     "node_modules/commondir": {
@@ -7560,6 +7753,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/jackspeak": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
+      "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/js-sdsl": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.4.tgz",
@@ -8458,6 +8669,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
+      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mocha": {
@@ -9431,6 +9651,31 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "node_modules/path-scurry": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+      "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^9.1.1 || ^10.0.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
+      "dev": true,
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -10115,9 +10360,9 @@
       }
     },
     "node_modules/reflect-metadata": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
-      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.1.tgz",
+      "integrity": "sha512-i5lLI6iw9AU3Uu4szRNPPEkomnkjRTaVt9hy/bn5g/oSzekBSMeLZblcjP74AW0vBabqERLLIrz+gR8QYR54Tw=="
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
@@ -10162,9 +10407,9 @@
       }
     },
     "node_modules/regexp-tree": {
-      "version": "0.1.24",
-      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.24.tgz",
-      "integrity": "sha512-s2aEVuLhvnVJW6s/iPgEGK6R+/xngd2jNQ+xy4bXNDKxZKJH6jpPHY6kVeVv1IeLCHgswRj+Kl3ELaDjG6V1iw==",
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
       "dev": true,
       "bin": {
         "regexp-tree": "bin/regexp-tree"
@@ -10909,7 +11154,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10927,7 +11171,6 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -11028,9 +11271,9 @@
       "dev": true
     },
     "node_modules/stack-utils": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
-      "integrity": "sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
       "dev": true,
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
@@ -11079,6 +11322,21 @@
       }
     },
     "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
@@ -11157,6 +11415,19 @@
       }
     },
     "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -12412,6 +12683,39 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "pretty-quick-staged": "pretty-quick --staged"
   },
   "dependencies": {
-    "@cucumber/gherkin-utils": "^8.0.0",
-    "@cucumber/messages": "^21.0.0",
-    "@cucumber/query": "^12.0.0",
-    "@cucumber/tag-expressions": "^5.0.0",
+    "@cucumber/gherkin-utils": "8.0.6",
+    "@cucumber/messages": "24.0.1",
+    "@cucumber/query": "12.0.1",
+    "@cucumber/tag-expressions": "6.1.0",
     "@fortawesome/fontawesome-svg-core": "6.2.1",
     "@fortawesome/free-solid-svg-icons": "6.2.1",
     "@fortawesome/react-fontawesome": "0.2.0",
@@ -55,11 +55,11 @@
     "react-dom": "~18"
   },
   "devDependencies": {
-    "@cucumber/compatibility-kit": "^12.0.0",
-    "@cucumber/fake-cucumber": "^16.0.0",
-    "@cucumber/gherkin": "^26.0.0",
-    "@cucumber/gherkin-streams": "^5.0.1",
-    "@cucumber/message-streams": "^4.0.1",
+    "@cucumber/compatibility-kit": "15.0.0",
+    "@cucumber/fake-cucumber": "16.4.0",
+    "@cucumber/gherkin": "28.0.0",
+    "@cucumber/gherkin-streams": "5.0.1",
+    "@cucumber/message-streams": "4.0.1",
     "@ladle/react": "^2.4.5",
     "@testing-library/react": "14.1.2",
     "@testing-library/user-event": "14.5.1",
@@ -108,7 +108,6 @@
     "typescript": "4.9.4"
   },
   "overrides": {
-    "@cucumber/messages": "^21.0.0",
     "uuid": "9.0.0"
   },
   "bugs": {

--- a/src/components/customise/customRendering.tsx
+++ b/src/components/customise/customRendering.tsx
@@ -62,7 +62,8 @@ export interface DocStringProps {
 export type DocStringClasses = Styles<'docString'>
 
 export interface ErrorMessageProps {
-  message: string
+  message?: string
+  children?: ReactNode
 }
 
 export type ErrorMessageClasses = Styles<'message'>

--- a/src/components/gherkin/ErrorMessage.tsx
+++ b/src/components/gherkin/ErrorMessage.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { FC } from 'react'
 
 import {
   DefaultComponent,
@@ -10,16 +10,17 @@ import defaultStyles from './ErrorMessage.module.scss'
 
 const DefaultRenderer: DefaultComponent<ErrorMessageProps, ErrorMessageClasses> = ({
   message,
+  children,
   styles,
 }) => {
-  return <pre className={styles.message}>{message}</pre>
+  return <pre className={styles.message}>{message ?? children}</pre>
 }
 
-export const ErrorMessage: React.FunctionComponent<ErrorMessageProps> = (props) => {
+export const ErrorMessage: FC<ErrorMessageProps> = ({ children, ...props }) => {
   const ResolvedRenderer = useCustomRendering<ErrorMessageProps, ErrorMessageClasses>(
     'ErrorMessage',
     defaultStyles,
     DefaultRenderer
   )
-  return <ResolvedRenderer {...props} />
+  return <ResolvedRenderer {...props}>{children}</ResolvedRenderer>
 }

--- a/src/components/gherkin/GherkinStep.tsx
+++ b/src/components/gherkin/GherkinStep.tsx
@@ -13,10 +13,10 @@ import CucumberQueryContext from '../../CucumberQueryContext.js'
 import GherkinQueryContext from '../../GherkinQueryContext.js'
 import { HighLight } from '../app/HighLight.js'
 import { DefaultComponent, GherkinStepProps, useCustomRendering } from '../customise/index.js'
+import { TestStepResultDetails } from '../results/index.js'
 import { Attachment } from './Attachment.js'
 import { DataTable as DataTableComponent } from './DataTable.js'
 import { DocString as DocStringComponent } from './DocString.js'
-import { ErrorMessage } from './ErrorMessage.js'
 import { Keyword } from './Keyword.js'
 import { Parameter } from './Parameter.js'
 import { StepItem } from './StepItem.js'
@@ -116,7 +116,7 @@ const DefaultRenderer: DefaultComponent<GherkinStepProps> = ({
       </Title>
       {step.dataTable && <DataTableComponent dataTable={step.dataTable} />}
       {step.docString && <DocStringComponent docString={step.docString} />}
-      {!hasExamples && testStepResult.message && <ErrorMessage message={testStepResult.message} />}
+      {!hasExamples && <TestStepResultDetails {...testStepResult} />}
       {!hasExamples &&
         attachments.map((attachment, i) => <Attachment key={i} attachment={attachment} />)}
     </StepItem>

--- a/src/components/gherkin/HookStep.tsx
+++ b/src/components/gherkin/HookStep.tsx
@@ -4,8 +4,8 @@ import React from 'react'
 
 import CucumberQueryContext from '../../CucumberQueryContext.js'
 import { HookStepProps, useCustomRendering } from '../customise/index.js'
+import { TestStepResultDetails } from '../results/index.js'
 import { Attachment } from './Attachment.js'
-import { ErrorMessage } from './ErrorMessage.js'
 import { StepItem } from './StepItem.js'
 import { Title } from './Title.js'
 
@@ -31,7 +31,7 @@ const DefaultRenderer: React.FunctionComponent<HookStepProps> = ({ step }) => {
         <Title header="h3" id={step.id}>
           {hook?.name ? `Hook "${hook.name}"` : 'Hook'} failed: {location}
         </Title>
-        {stepResult.message && <ErrorMessage message={stepResult.message} />}
+        <TestStepResultDetails {...stepResult} />
         {attachments.map((attachment, i) => (
           <Attachment key={i} attachment={attachment} />
         ))}

--- a/src/components/results/TestStepResultDetails.spec.tsx
+++ b/src/components/results/TestStepResultDetails.spec.tsx
@@ -1,0 +1,65 @@
+import { TestStepResultStatus } from '@cucumber/messages'
+import { expect } from 'chai'
+import React from 'react'
+
+import { render } from '../../../test-utils/index.js'
+import { TestStepResultDetails } from './TestStepResultDetails.js'
+
+describe('TestStepResultDetails', () => {
+  it('should render nothing if no message or exception', () => {
+    const { container } = render(
+      <TestStepResultDetails
+        duration={{ seconds: 1, nanos: 0 }}
+        status={TestStepResultStatus.PASSED}
+      />
+    )
+
+    expect(container).to.be.empty
+  })
+
+  it('should render the message for a legacy message', () => {
+    const { container } = render(
+      <TestStepResultDetails
+        duration={{ seconds: 1, nanos: 0 }}
+        status={TestStepResultStatus.FAILED}
+        message="Oh no a bad thing happened"
+      />
+    )
+
+    expect(container).to.include.text('Oh no a bad thing happened')
+  })
+
+  it('should render the message for a typed exception', () => {
+    const { container } = render(
+      <TestStepResultDetails
+        duration={{ seconds: 1, nanos: 0 }}
+        status={TestStepResultStatus.FAILED}
+        message="Dont use the legacy field"
+        exception={{
+          type: 'Whoopsie',
+          message: 'Bad things happened',
+        }}
+      />
+    )
+
+    expect(container).to.include.text('Whoopsie Bad things happened')
+    expect(container).not.to.include.text('Dont use the legacy field')
+  })
+
+  it('should render a stack trace where present', () => {
+    const { container } = render(
+      <TestStepResultDetails
+        duration={{ seconds: 1, nanos: 0 }}
+        status={TestStepResultStatus.FAILED}
+        message="Dont use the legacy field"
+        exception={{
+          type: 'Whoopsie',
+          message: 'Bad things happened',
+          stackTrace: 'at /some/file.js:1:2',
+        }}
+      />
+    )
+
+    expect(container).to.include.text('at /some/file.js:1:2')
+  })
+})

--- a/src/components/results/TestStepResultDetails.stories.tsx
+++ b/src/components/results/TestStepResultDetails.stories.tsx
@@ -1,0 +1,65 @@
+import { TestStepResult, TestStepResultStatus } from '@cucumber/messages'
+import { Story } from '@ladle/react'
+import React from 'react'
+
+import { CucumberReact } from '../CucumberReact.js'
+import { TestStepResultDetails } from './TestStepResultDetails.js'
+
+export default {
+  title: 'Results/TestStepResultDetails',
+}
+
+type TemplateArgs = {
+  result: TestStepResult
+}
+
+const Template: Story<TemplateArgs> = ({ result }) => {
+  return (
+    <CucumberReact>
+      <TestStepResultDetails {...result} />
+    </CucumberReact>
+  )
+}
+
+export const Legacy = Template.bind({})
+Legacy.args = {
+  result: {
+    status: TestStepResultStatus.FAILED,
+    message: 'Oh no a bad thing happened!',
+  },
+}
+
+export const NothingToSee = Template.bind({})
+NothingToSee.args = {
+  result: {
+    status: TestStepResultStatus.PASSED,
+  },
+}
+
+export const TypedException = Template.bind({})
+TypedException.args = {
+  result: {
+    status: TestStepResultStatus.FAILED,
+    message:
+      "TypeError: Cannot read properties of null (reading 'type')\n    at TodosPage.addItem (/Users/somebody/Projects/my-project/support/pages/TodosPage.ts:39:21)\n    at processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at CustomWorld.<anonymous> (/Users/somebody/Projects/my-project/support/steps/steps.ts:20:5)",
+    exception: {
+      type: 'TypeError',
+      message: "Cannot read properties of null (reading 'type')",
+    },
+  },
+}
+
+export const WithStackTrace = Template.bind({})
+WithStackTrace.args = {
+  result: {
+    status: TestStepResultStatus.FAILED,
+    message:
+      "TypeError: Cannot read properties of null (reading 'type')\n    at TodosPage.addItem (/Users/somebody/Projects/my-project/support/pages/TodosPage.ts:39:21)\n    at processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at CustomWorld.<anonymous> (/Users/somebody/Projects/my-project/support/steps/steps.ts:20:5)",
+    exception: {
+      type: 'TypeError',
+      message: "Cannot read properties of null (reading 'type')",
+      stackTrace:
+        '    at TodosPage.addItem (/Users/somebody/Projects/my-project/support/pages/TodosPage.ts:39:21)\n    at processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at CustomWorld.<anonymous> (/Users/somebody/Projects/my-project/support/steps/steps.ts:20:5)',
+    },
+  },
+}

--- a/src/components/results/TestStepResultDetails.tsx
+++ b/src/components/results/TestStepResultDetails.tsx
@@ -1,0 +1,19 @@
+import { TestStepResult } from '@cucumber/messages'
+import React, { FC } from 'react'
+
+import { ErrorMessage } from '../gherkin/index.js'
+
+export const TestStepResultDetails: FC<TestStepResult> = ({ message, exception }) => {
+  if (exception) {
+    return (
+      <ErrorMessage>
+        <strong>{exception.type}</strong> {exception.message}
+        {exception.stackTrace && <div>{exception.stackTrace}</div>}
+      </ErrorMessage>
+    )
+  }
+  if (message) {
+    return <ErrorMessage>{message}</ErrorMessage>
+  }
+  return null
+}

--- a/src/components/results/index.ts
+++ b/src/components/results/index.ts
@@ -1,0 +1,1 @@
+export * from './TestStepResultDetails.js'


### PR DESCRIPTION
### 🤔 What's changed?

This PR adds support in the components for an `exception` object within the `TestStepResult`. This is designed to give more structured information about a problem than the flat string `message` field. We'll now use the exception (and disregard the old message field) if present.

### ⚡️ What's your motivation? 

Make use of the structured exception object for Cucumber implementations that support it, whilst maintaining backwards-compatibility with those that don't yet.

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
