### PR TITLE
refactor: Add in new ability to store passed/total as a bracketed total

### DIFF
--- a/src/components/app/ExecutionSummary.tsx
+++ b/src/components/app/ExecutionSummary.tsx
@@ -6,6 +6,7 @@ import React, { FC } from 'react'
 import { formatExecutionDistance } from '../../formatExecutionDistance.js'
 import { formatExecutionDuration } from '../../formatExecutionDuration.js'
 import { formatStatusRate } from '../../formatStatusRate.js'
+import { formatPassedQuantity } from '../../formatPassedQuantity.js'
 import { useQueries } from '../../hooks/index.js'
 import { useResultStatistics } from '../../hooks/useResultStatistics.js'
 import { CICommitLink } from './CICommitLink.js'
@@ -60,6 +61,10 @@ export const ExecutionSummary: FC = () => {
             <HealthChart />
             <span>
               {formatStatusRate(
+                scenarioCountByStatus[TestStepResultStatus.PASSED],
+                totalScenarioCount
+              )}
+              {formatPassedQuantity(
                 scenarioCountByStatus[TestStepResultStatus.PASSED],
                 totalScenarioCount
               )}

--- a/src/formatPassedQuantity.spec.ts
+++ b/src/formatPassedQuantity.spec.ts
@@ -1,0 +1,22 @@
+import { expect } from 'chai'
+
+import { formatPassedQuantity } from './formatPassedQuantity.js'
+
+describe('formatPassedQuantity', () => {
+  const examples: [passed: number, total: number, proportion: string][] = [
+    [13, 45, '(13 / 45)'],
+    [5, 45, '(5 / 45)'],
+    [45, 45, '(45 / 45)'],
+    [0, 45, '(0 / 45)'],
+    [0, 0, '(0 / 0)'],
+    [999, 1000, '(999 / 1000)'],
+    [99999, 100000, '(99999 / 100000)'],
+    [9999999, 10000000, '(9999999 / 10000000)'],
+  ]
+
+  for (const [passed, total, proportion] of examples) {
+    it(`should render correctly for ${proportion}`, () => {
+      expect(formatPassedQuantity(passed, total)).to.eq(proportion)
+    })
+  }
+})

--- a/src/formatPassedQuantity.ts
+++ b/src/formatPassedQuantity.ts
@@ -1,0 +1,3 @@
+export function formatPassedQuantity(passed: number, total: number) {
+  return `(${passed} / ${total})`
+}


### PR DESCRIPTION
### 🤔 What's changed?

Add in ability to store the passed/total as a bracketed string

### ⚡️ What's your motivation? 

Previous incarnations of html-formatter showed the total scenarios ran in 2 places. We should retain at least 1

Goal is to change

```
100% passed | 78% passed | 50% passed
```

to ....

```
100% (8 / 8), passed | 78% (78 / 100), passed | 50% (1 / 2), passed
```

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

Way I've done it

### 📋 Checklist:

- Is this correct?
