### PR TITLE
Improve useFilteredTestCases

### DIFF
--- a/src/hooks/useFilteredTestCases.spec.tsx
+++ b/src/hooks/useFilteredTestCases.spec.tsx
@@ -17,12 +17,8 @@ interface ProviderProps {
   defaultHideStatuses?: readonly TestStepResultStatus[]
 }
 
-function renderAndExtractPickleNames({
-  envelopes,
-  defaultQuery,
-  defaultHideStatuses,
-}: ProviderProps) {
-  return renderHook(() => useFilteredTestCases().map(({ pickle }) => pickle.name), {
+function renderFilteredTestCases({ envelopes, defaultQuery, defaultHideStatuses }: ProviderProps) {
+  return renderHook(useFilteredTestCases, {
     wrapper: ({ children }) => (
       <EnvelopesProvider envelopes={envelopes}>
         <InMemorySearchProvider
@@ -34,6 +30,18 @@ function renderAndExtractPickleNames({
       </EnvelopesProvider>
     ),
   })
+}
+
+function renderAndExtractPickleNames(props: ProviderProps) {
+  const { result, ...rest } = renderFilteredTestCases(props)
+  return {
+    result: {
+      get current() {
+        return (result.current.results ?? []).map(({ pickle }) => pickle.name)
+      },
+    },
+    ...rest,
+  }
 }
 
 describe('useFilteredTestCases', () => {
@@ -146,6 +154,53 @@ describe('useFilteredTestCases', () => {
 
       await waitFor(() => expect(result.current).to.include('one scenario'))
       expect(result.current).to.include('another scenario')
+    })
+  })
+
+  describe('readiness', () => {
+    it('leaves results undefined while the search is still running', () => {
+      const { result } = renderFilteredTestCases({ envelopes: retry, defaultQuery: 'third' })
+
+      expect(result.current.results).to.equal(undefined)
+    })
+
+    it('populates results once the search resolves', async () => {
+      const { result } = renderFilteredTestCases({ envelopes: retry, defaultQuery: 'third' })
+
+      await waitFor(() => expect(result.current.results).not.to.equal(undefined))
+    })
+  })
+
+  describe('the filtered flag', () => {
+    it('is false when no criteria are active', async () => {
+      const { result } = renderFilteredTestCases({ envelopes: hooksConditional })
+
+      await waitFor(() => expect(result.current.results).to.have.lengthOf(3))
+      expect(result.current.filtered).to.equal(false)
+    })
+
+    it('is true when a tag expression is active', async () => {
+      const { result } = renderFilteredTestCases({
+        envelopes: hooksConditional,
+        defaultQuery: '@fail-before',
+      })
+
+      await waitFor(() => expect(result.current.filtered).to.equal(true))
+    })
+
+    it('is true when a text search is active', async () => {
+      const { result } = renderFilteredTestCases({ envelopes: retry, defaultQuery: 'third' })
+
+      await waitFor(() => expect(result.current.filtered).to.equal(true))
+    })
+
+    it('is true when statuses are hidden', async () => {
+      const { result } = renderFilteredTestCases({
+        envelopes: retry,
+        defaultHideStatuses: [TestStepResultStatus.FAILED],
+      })
+
+      await waitFor(() => expect(result.current.filtered).to.equal(true))
     })
   })
 })

--- a/src/hooks/useFilteredTestCases.ts
+++ b/src/hooks/useFilteredTestCases.ts
@@ -9,13 +9,16 @@ import { useQueries } from './useQueries.js'
 import { useSearch } from './useSearch.js'
 import { useSearchResult } from './useSearchResult.js'
 
-export function useFilteredTestCases(): ReadonlyArray<ExpandedTestCase<TestCaseFinished>> {
+export function useFilteredTestCases(): {
+  results?: ReadonlyArray<ExpandedTestCase<TestCaseFinished>>
+  filtered: boolean
+} {
   const { cucumberQuery } = useQueries()
   const allTestCasesFinished = useMemo(
     () => cucumberQuery.findAllTestCaseFinished(),
     [cucumberQuery]
   )
-  const { hideStatuses, tagExpression } = useSearch()
+  const { hideStatuses, tagExpression, unchanged } = useSearch()
   const candidates = useMemo(
     () =>
       filterAndExpandTestCaseEvents(cucumberQuery, allTestCasesFinished, {
@@ -25,7 +28,7 @@ export function useFilteredTestCases(): ReadonlyArray<ExpandedTestCase<TestCaseF
     [allTestCasesFinished, cucumberQuery, hideStatuses, tagExpression]
   )
   const searchResult = useSearchResult()
-  const [results, setResults] = useState<ReadonlyArray<ExpandedTestCase<TestCaseFinished>>>([])
+  const [results, setResults] = useState<ReadonlyArray<ExpandedTestCase<TestCaseFinished>>>()
 
   useEffect(() => {
     switch (searchResult.status) {
@@ -43,5 +46,8 @@ export function useFilteredTestCases(): ReadonlyArray<ExpandedTestCase<TestCaseF
     }
   }, [candidates, searchResult])
 
-  return results
+  return {
+    results,
+    filtered: !unchanged,
+  }
 }


### PR DESCRIPTION
### 🤔 What's changed?

- `useFilteredTestCases` now returns an object that includes a `filtered` flag
- The `results` prop can also be undefined to indicate an async search hasn't finished

### ⚡️ What's your motivation? 

Fixes https://github.com/cucumber/react-components/issues/558

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)
- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
