### PR TITLE
Replace ANSI handling library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - Add directory hierarchy awareness to document sorting ([#517](https://github.com/cucumber/react-components/pull/517)) by [@MuhammadTalha57](https://github.com/MuhammadTalha57)
+- Replace ANSI handling library ([#562](https://github.com/cucumber/react-components/pull/562))
 
 ## [24.3.0] - 2026-04-13
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@orama/orama": "^3.0.0",
         "@orama/stemmers": "^3.0.0",
         "@teppeis/multimaps": "3.0.0",
-        "ansi-to-html": "0.7.2",
+        "ansi_up": "6.0.6",
         "date-fns": "4.4.0",
         "hast-util-sanitize": "^5.0.1",
         "highlight-words-core": "1.2.3",
@@ -511,9 +511,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -531,9 +528,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -551,9 +545,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -571,9 +562,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -3971,6 +3959,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/ansi_up": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/ansi_up/-/ansi_up-6.0.6.tgz",
+      "integrity": "sha512-yIa1x3Ecf8jWP4UWEunNjqNX6gzE4vg2gGz+xqRGY+TBSucnYp6RRdPV4brmtg6bQ1ljD48mZ5iGSEj7QEpRKA==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ansi-align": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
@@ -4030,20 +4027,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/ansi-to-html": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/ansi-to-html/-/ansi-to-html-0.7.2.tgz",
-      "integrity": "sha512-v6MqmEpNlxF+POuyhKkidusCHWWkaLcGRURzivcU3I9tv7k4JVhFcnukrM5Rlk2rUywdZuzYAZ+kbZqWCnfN3g==",
-      "dependencies": {
-        "entities": "^2.2.0"
-      },
-      "bin": {
-        "ansi-to-html": "bin/ansi-to-html"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/append-transform": {
@@ -5211,14 +5194,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -12255,6 +12230,22 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-tsconfig-paths/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/vite/node_modules/fdir": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@orama/orama": "^3.0.0",
     "@orama/stemmers": "^3.0.0",
     "@teppeis/multimaps": "3.0.0",
-    "ansi-to-html": "0.7.2",
+    "ansi_up": "6.0.6",
     "date-fns": "4.4.0",
     "hast-util-sanitize": "^5.0.1",
     "highlight-words-core": "1.2.3",

--- a/src/components/gherkin/attachment/Attachment.spec.tsx
+++ b/src/components/gherkin/attachment/Attachment.spec.tsx
@@ -315,7 +315,7 @@ describe('<Attachment>', () => {
       const { container } = render(<Attachment attachment={attachment} />)
       const data = container.querySelector('pre > span')
       expect(data).to.contain.html(
-        '<span style="color:#000">black<span style="color:#AAA">white</span></span>'
+        '<span style="color:rgb(0,0,0)">black</span><span style="color:rgb(255,255,255)">white</span>'
       )
       expect(screen.getByRole('button', { name: 'Copy' })).to.be.visible
     })
@@ -330,8 +330,20 @@ describe('<Attachment>', () => {
       const { container } = render(<Attachment attachment={attachment} />)
       const data = container.querySelector('pre > span')
       expect(data).to.contain.html(
-        '<span style="color:#000">black<span style="color:#AAA">white</span></span>'
+        '<span style="color:rgb(0,0,0)">black</span><span style="color:rgb(255,255,255)">white</span>'
       )
+    })
+
+    it('escapes HTML in the log content', () => {
+      const attachment: AttachmentMessage = {
+        mediaType: 'text/x.cucumber.log+plain',
+        body: '<img src=x onerror=alert(1)>',
+        contentEncoding: AttachmentContentEncoding.IDENTITY,
+      }
+      const { container } = render(<Attachment attachment={attachment} />)
+      const data = container.querySelector('pre > span')
+      expect(data?.querySelector('img')).to.equal(null)
+      expect(data).to.have.text('<img src=x onerror=alert(1)>')
     })
 
     it('copies raw content without ANSI conversion when clicking copy button', async () => {

--- a/src/components/gherkin/attachment/Log.tsx
+++ b/src/components/gherkin/attachment/Log.tsx
@@ -1,7 +1,7 @@
 // biome-ignore-all lint/security/noDangerouslySetInnerHtml: pre-sanitised
 
 import type { Attachment } from '@cucumber/messages'
-import Convert from 'ansi-to-html'
+import { AnsiUp } from 'ansi_up'
 import type { FC } from 'react'
 
 import { CopyButton } from '../../app/CopyButton.js'
@@ -24,5 +24,5 @@ export const Log: FC<{
 }
 
 function prettyANSI(s: string) {
-  return new Convert().toHtml(s)
+  return new AnsiUp().ansi_to_html(s)
 }


### PR DESCRIPTION
### 🤔 What's changed?

Replace `ansi-to-html` with `ansi_up`.

### ⚡️ What's your motivation? 

`ansi-to-html` was unmaintained, and bundler changes are starting to cause issues with it e.g. https://github.com/cucumber/html-formatter/pull/540 where webpack's changed wrapping of CommonJS-exported functions broke our usage.

`ansi_up` doesn't have this issue. It also automatically sanitises the input text for XSS, which our old code implied it did, but didn't.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)
- :bug: Bug fix (non-breaking change which fixes a defect)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
